### PR TITLE
ci: add docker-compose for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - '8000:8000'
+    volumes:
+      - ./app:/app
+      - ./config:/config
+    environment:
+      - CONFIG_PATH=/config/config.yml
+    restart: unless-stopped


### PR DESCRIPTION
proposal testing_projects 📜 #1

Add docker-compose with an `app` service for development. Mounts code and config into the container.

Testing:
- Run `docker-compose up --build` and ensure container starts. (Full app endpoints added in later stages.)