### PR TITLE
chore(db): add migration 0001_add_history

### DIFF
--- a/app/migrations/0001_add_history.py
+++ b/app/migrations/0001_add_history.py
@@ -1,0 +1,22 @@
+"""
+Simple one-shot migration runner to create device_history if missing.
+Run: python -m app.migrations.0001_add_history
+"""
+from ..models import Database
+
+def migrate():
+    db = Database('data/rpi_nms.db')
+    db.init_db()
+    with db.conn() as c:
+        c.execute("""
+        CREATE TABLE IF NOT EXISTS device_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ip TEXT NOT NULL,
+            alive INTEGER NOT NULL,
+            ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """)
+    print("migration 0001 applied")
+
+if __name__ == '__main__':
+    migrate()


### PR DESCRIPTION
🎟️#9

Adds a small migration helper. On deployment run `python -m app.migrations.0001_add_history` to ensure history table exists.

Testing:
- Run the script on a dev DB and confirm table present.
